### PR TITLE
Derive serde Serialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ dmx-struct = "0.1.0"
 regex = "1.5.4"
 lazy_static = "1.4.0"
 unicode-segmentation = "1.7.1"
+serde = { version = "1.0.182", features = ["derive"] }
 
 [dev-dependencies]
 backtrace = "0.3.59"

--- a/src/fixture_type/attribute_definitions/attribute/mod.rs
+++ b/src/fixture_type/attribute_definitions/attribute/mod.rs
@@ -3,6 +3,7 @@ use std::fmt::Debug;
 
 use quick_xml::events::BytesStart;
 use quick_xml::Reader;
+use serde::{Serialize, Deserialize};
 
 use crate::utils::errors::GdtfError;
 use crate::utils::read;
@@ -17,7 +18,7 @@ use crate::utils::units::node::Node;
 use crate::utils::units::physical_unit::PhysicalUnit;
 
 ///Describes a singular mutual exclusive control function
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct Attribute {
     /// The pretty name of the attribute
     pub pretty: String,

--- a/src/fixture_type/attribute_definitions/feature_group/mod.rs
+++ b/src/fixture_type/attribute_definitions/feature_group/mod.rs
@@ -7,6 +7,7 @@ use std::fmt::Debug;
 use quick_xml::events::attributes::Attribute;
 use quick_xml::events::BytesStart;
 use quick_xml::Reader;
+use serde::{Serialize, Deserialize};
 
 use crate::fixture_type::attribute_definitions::feature_group::feature::Feature;
 use crate::utils::errors::GdtfError;
@@ -18,7 +19,7 @@ use crate::utils::units::name::Name;
 
 pub(crate) mod feature;
 
-#[derive(Debug, PartialEq, Clone, Default)]
+#[derive(Debug, PartialEq, Clone, Default, Serialize, Deserialize)]
 ///Groups the logical control elements called Feature into a structured way for easier access and finding
 pub struct FeatureGroup {
     /// The pretty name of the feature group

--- a/src/fixture_type/attribute_definitions/mod.rs
+++ b/src/fixture_type/attribute_definitions/mod.rs
@@ -4,6 +4,7 @@ use std::fmt::Debug;
 
 use quick_xml::events::BytesStart;
 use quick_xml::Reader;
+use serde::{Serialize, Deserialize};
 
 use crate::fixture_type::attribute_definitions::activation_group::ActivationGroup;
 use crate::fixture_type::attribute_definitions::attribute::Attribute;
@@ -20,7 +21,7 @@ pub(crate) mod activation_group;
 pub mod attribute;
 pub mod feature_group;
 
-#[derive(Debug, Clone, PartialEq, Default)]
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 /// Defines the attribute definitions for the Fixture Type Attributes.
 pub struct AttributeDefinitions {
     ///Describes the logical grouping of attributes. For example, Gobo 1 and Gobo 2 are grouped in the feature Gobo of the feature group Gobo.

--- a/src/fixture_type/dmx_mode/dmx_channel/logical_channel/channel_function/channel_set/mod.rs
+++ b/src/fixture_type/dmx_mode/dmx_channel/logical_channel/channel_function/channel_set/mod.rs
@@ -4,6 +4,7 @@ use std::fmt::Debug;
 use quick_xml::events::attributes::Attribute;
 use quick_xml::events::BytesStart;
 use quick_xml::Reader;
+use serde::{Serialize, Deserialize};
 
 use crate::fixture_type::dmx_mode::dmx_channel::logical_channel::channel_function::ChannelFunction;
 use crate::utils::errors::GdtfError;
@@ -14,7 +15,7 @@ use crate::utils::read::TestReadGdtf;
 use crate::utils::units::dmx_value::DmxValue;
 use crate::utils::units::name::Name;
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 /// Defines the channel sets of the channel function
 pub struct ChannelSet {
     ///Start DMX value; The end DMX value is calculated as a DMXFrom of the next channel set – 1 or the maximum value of the current channel function

--- a/src/fixture_type/dmx_mode/dmx_channel/logical_channel/channel_function/mod.rs
+++ b/src/fixture_type/dmx_mode/dmx_channel/logical_channel/channel_function/mod.rs
@@ -6,6 +6,7 @@ use std::fmt::Debug;
 use quick_xml::events::attributes::Attribute as XmlAttribute;
 use quick_xml::events::BytesStart;
 use quick_xml::Reader;
+use serde::{Serialize, Deserialize};
 
 use crate::fixture_type::dmx_mode::dmx_channel::logical_channel::channel_function::channel_set::ChannelSet;
 use crate::fixture_type::dmx_mode::dmx_channel::logical_channel::LogicalChannel;
@@ -21,7 +22,7 @@ use crate::utils::units::node::{GdtfNodeError, Node};
 pub mod channel_set;
 
 ///The Fixture Type Attribute is assinged to a Channel Function and defines the function of its DMX Range
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ChannelFunction {
     ///Link to attribute; Starting point is the attributes node_2. Default value: “NoFeature”.
     pub attribute: Attribute,
@@ -489,7 +490,7 @@ impl TestReadGdtf for ChannelFunction {
 //-----------------------------------------------------------------------------------------------------------------
 //-----------------------------------------------------------------------------------------------------------------
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 ///Node used in ChannelFunction.attribute. Link to attribute; Starting point is the attributes node. Default value: “NoFeature”.
 pub enum Attribute {
     ///Used when a reference to a node is present
@@ -565,7 +566,7 @@ impl Default for Attribute {
 //-----------------------------------------------------------------------------------------------------------------
 //-----------------------------------------------------------------------------------------------------------------
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct ModeMaster {
     ///Link to DMX Channel or Channel Function; Starting point DMX mode
     pub mode_master: Node,

--- a/src/fixture_type/dmx_mode/dmx_channel/logical_channel/mod.rs
+++ b/src/fixture_type/dmx_mode/dmx_channel/logical_channel/mod.rs
@@ -1,6 +1,7 @@
 //! Contains LogicalChannel and it's children
 use std::collections::HashMap;
 use std::fmt::Debug;
+use serde::{Serialize, Deserialize};
 
 use quick_xml::events::attributes::Attribute;
 use quick_xml::events::BytesStart;
@@ -19,7 +20,7 @@ use crate::utils::units::node::Node;
 pub mod channel_function;
 
 ///The Fixture Type Attribute is assinged to a LogicalChannel and defines the function of the LogicalChannel. All logical channels that are children of the same DMX channel are mutually exclusive. In a DMX mode, only one logical channel with the same attribute can reference the same geometry at a time.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct LogicalChannel {
     ///Link to the attribute; The starting point is the Attribute Collect
     pub attribute: Node,
@@ -220,7 +221,7 @@ impl TestReadGdtf for LogicalChannel {
 
 ///Snap representation for Snap for LogicalChannel used in GDTF
 /// If snap is enabled, the logical channel will not fade between values. Instead, it will jump directly to the new value
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub enum Snap {
     No,
     Yes,
@@ -294,7 +295,7 @@ impl Snap {
 
 ///Master representation for logicalChannel in GDTF
 ///Defines if all the subordinate channel functions react to a Group Control defined by the control system
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub enum Master {
     None,
     Grand,

--- a/src/fixture_type/dmx_mode/dmx_channel/mod.rs
+++ b/src/fixture_type/dmx_mode/dmx_channel/mod.rs
@@ -5,6 +5,7 @@ use std::str::FromStr;
 use quick_xml::events::attributes::Attribute;
 use quick_xml::events::BytesStart;
 use quick_xml::Reader;
+use serde::{Serialize, Deserialize};
 
 use crate::fixture_type::dmx_mode::dmx_channel::logical_channel::LogicalChannel;
 use crate::utils::errors::GdtfError;
@@ -19,7 +20,7 @@ use crate::utils::units::node::Node;
 pub mod logical_channel;
 
 ///This section defines the DMX channe
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct DmxChannel {
     ///Number of the DMXBreak; Default value: 1; Special value: “Overwrite” – means that this number will be overwritten by Geometry Reference; Size: 4 bytes
     pub dmx_break: DmxBreak,
@@ -280,7 +281,7 @@ impl TestReadGdtf for DmxChannel {
 
 ///The unit Offset used for DMXChannel used in GDTF
 ///Relative addresses of the current DMX channel from highest to least significant
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct Offset(pub Vec<i32>);
 
 impl Offset {
@@ -366,7 +367,7 @@ impl Offset {
 //-----------------------------------------------------------------------------------------------------------------
 
 ///DMXBreak used for DMXChannel in GDTF
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub enum DmxBreak {
     ///Number of the DMXBreak; Default value: 1
     Value(u32),

--- a/src/fixture_type/dmx_mode/ft_macro/macro_dmx_step/macro_dmx_value/mod.rs
+++ b/src/fixture_type/dmx_mode/ft_macro/macro_dmx_step/macro_dmx_value/mod.rs
@@ -5,6 +5,7 @@ use std::fmt::Debug;
 use quick_xml::events::attributes::Attribute;
 use quick_xml::events::BytesStart;
 use quick_xml::Reader;
+use serde::{Serialize, Deserialize};
 
 use crate::fixture_type::dmx_mode::ft_macro::macro_dmx_step::MacroDmxStep;
 use crate::utils::errors::GdtfError;
@@ -15,7 +16,7 @@ use crate::utils::units::dmx_value::DmxValue;
 use crate::utils::units::node::Node;
 
 ///Defines a dmx value for a step in a macro
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct MacroDmxValue {
     ///Value of the DMX channel
     pub value: DmxValue,

--- a/src/fixture_type/dmx_mode/ft_macro/macro_dmx_step/mod.rs
+++ b/src/fixture_type/dmx_mode/ft_macro/macro_dmx_step/mod.rs
@@ -4,6 +4,7 @@ use std::fmt::Debug;
 use quick_xml::events::attributes::Attribute;
 use quick_xml::events::BytesStart;
 use quick_xml::Reader;
+use serde::{Serialize, Deserialize};
 
 use crate::fixture_type::dmx_mode::ft_macro::macro_dmx_step::macro_dmx_value::MacroDmxValue;
 use crate::utils::errors::GdtfError;
@@ -15,7 +16,7 @@ use crate::utils::read::TestReadGdtf;
 pub mod macro_dmx_value;
 
 ///Defines a DMX sequence for a macro
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct MacroDmxStep {
     ///Duration of a step; Default value: 1; Unit: seconds.
     pub duration: f32,

--- a/src/fixture_type/dmx_mode/ft_macro/mod.rs
+++ b/src/fixture_type/dmx_mode/ft_macro/mod.rs
@@ -4,6 +4,7 @@ use std::fmt::Debug;
 use quick_xml::events::attributes::Attribute;
 use quick_xml::events::BytesStart;
 use quick_xml::Reader;
+use serde::{Serialize, Deserialize};
 
 use crate::fixture_type::dmx_mode::ft_macro::macro_dmx_step::MacroDmxStep;
 use crate::utils::errors::GdtfError;
@@ -15,7 +16,7 @@ use crate::utils::units::name::Name;
 pub mod macro_dmx_step;
 
 ///Describes a macro defined by the manufacturer
-#[derive(Debug, PartialEq, Clone, Default)]
+#[derive(Debug, PartialEq, Clone, Default, Serialize, Deserialize)]
 pub struct FtMacro {
     ///All steps to execute the Macro
     pub macro_dmx_steps: Vec<MacroDmxStep>,

--- a/src/fixture_type/dmx_mode/mod.rs
+++ b/src/fixture_type/dmx_mode/mod.rs
@@ -5,6 +5,7 @@ use std::fmt::Debug;
 use quick_xml::events::attributes::Attribute;
 use quick_xml::events::BytesStart;
 use quick_xml::Reader;
+use serde::{Serialize, Deserialize};
 
 use crate::fixture_type::dmx_mode::dmx_channel::DmxChannel;
 use crate::fixture_type::dmx_mode::ft_macro::FtMacro;
@@ -21,7 +22,7 @@ pub mod ft_macro;
 pub mod relation;
 
 ///Each DMX mode describes logical control a part of the device in a specific mode
-#[derive(Debug, PartialEq, Clone, Default)]
+#[derive(Debug, PartialEq, Clone, Default, Serialize, Deserialize)]
 pub struct DmxMode {
     ///Name of the first geometry in the device; Only top level geometries are allowed to be linked.
     pub geometry: Name,

--- a/src/fixture_type/dmx_mode/relation/mod.rs
+++ b/src/fixture_type/dmx_mode/relation/mod.rs
@@ -3,6 +3,7 @@ use std::fmt::Debug;
 use quick_xml::events::attributes::Attribute;
 use quick_xml::events::BytesStart;
 use quick_xml::Reader;
+use serde::{Serialize, Deserialize};
 
 use crate::utils::errors::GdtfError;
 use crate::utils::read;
@@ -13,7 +14,7 @@ use crate::utils::units::name::Name;
 use crate::utils::units::node::Node;
 
 ///Relation between the master DMX channel and the following logical channel
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct Relation {
     ///Link to the master DMX channel; Starting point: DMX mode
     pub master: Node,
@@ -153,7 +154,7 @@ impl TestReadGdtf for Relation {
 //-----------------------------------------------------------------------------------------------------------------
 //-----------------------------------------------------------------------------------------------------------------
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 ///Type of the relation; Values: “Multiply”, “Override”
 pub enum RelationType {
     Multiply,

--- a/src/fixture_type/mod.rs
+++ b/src/fixture_type/mod.rs
@@ -4,6 +4,7 @@ use std::fmt::Debug;
 
 use quick_xml::events::BytesStart;
 use quick_xml::Reader;
+use serde::{Serialize, Deserialize};
 
 #[cfg(test)]
 use crate::fixture_type::attribute_definitions::activation_group::ActivationGroup;
@@ -31,7 +32,7 @@ pub mod physical_descriptions;
 pub mod wheel;
 
 ///The FixtureType node_2 is the starting point of the description of the fixture type
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct FixtureType {
     ///Name of the fixture type.
     pub name: Name,
@@ -312,7 +313,7 @@ impl TestReadGdtf for FixtureType {
 //-----------------------------------------------------------------------------------------------------------------
 
 ///Describes if it is possible to mount other devices to this device. Value: “Yes”, “No”. Default value: “Yes”
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub enum CanHaveChildren {
     Yes,
     No,

--- a/src/fixture_type/physical_descriptions/color_space/mod.rs
+++ b/src/fixture_type/physical_descriptions/color_space/mod.rs
@@ -2,6 +2,7 @@
 use quick_xml::events::attributes::Attribute;
 use quick_xml::events::BytesStart;
 use quick_xml::Reader;
+use serde::{Serialize, Deserialize};
 
 use crate::utils::errors::GdtfError;
 use crate::utils::read;
@@ -11,7 +12,7 @@ use crate::utils::read::TestReadGdtf;
 use crate::utils::units::color_cie::ColorCie;
 
 ///Defines the color space that is used for color mixing with indirect RGB, Hue/Sat, xyY or CMY control input
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct ColorSpace {
     ///CIE xyY of the Red Primary
     pub red: ColorCie,

--- a/src/fixture_type/physical_descriptions/connectors/mod.rs
+++ b/src/fixture_type/physical_descriptions/connectors/mod.rs
@@ -1,5 +1,6 @@
 //!defines the connector
 use std::str::FromStr;
+use serde::{Serialize, Deserialize};
 
 use quick_xml::events::attributes::Attribute;
 use quick_xml::events::BytesStart;
@@ -17,7 +18,7 @@ use crate::utils::units::connector_type::ConnectorType;
 use crate::utils::units::name::Name;
 
 ///defines the connector
-#[derive(Debug, PartialEq, Default, Clone)]
+#[derive(Debug, PartialEq, Default, Clone, Serialize, Deserialize)]
 pub struct Connector {
     ///The type of the connector. Find a list of predefined types in Annex D.
     pub connector_type: ConnectorType,
@@ -30,7 +31,7 @@ pub struct Connector {
 }
 
 ///Connectors where the addition of the Gender value equals 0, can be connected; Default value: 0; Male Connectors are −1, Female are +1, Universal are 0.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub enum ConnectionGender {
     Male = -1,
     Neutral = 0,

--- a/src/fixture_type/physical_descriptions/cris/cri/mod.rs
+++ b/src/fixture_type/physical_descriptions/cris/cri/mod.rs
@@ -1,5 +1,6 @@
 //!Defines the CRI for one of the 99 color samples
 use std::str::FromStr;
+use serde::{Serialize, Deserialize};
 
 use lazy_static::lazy_static;
 use quick_xml::events::attributes::Attribute;
@@ -15,7 +16,7 @@ use crate::utils::read::ReadGdtf;
 use crate::utils::read::TestReadGdtf;
 
 ///Defines the CRI for one of the 99 color samples
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct Cri {
     ///Color sample. The defined values are “CES01”, “CES02”, … “CES99”. Default Value “CES01"
     pub ces: u8,

--- a/src/fixture_type/physical_descriptions/cris/mod.rs
+++ b/src/fixture_type/physical_descriptions/cris/mod.rs
@@ -2,6 +2,7 @@
 use quick_xml::events::attributes::Attribute;
 use quick_xml::events::BytesStart;
 use quick_xml::Reader;
+use serde::{Serialize, Deserialize};
 
 use crate::fixture_type::physical_descriptions::cris::cri::Cri;
 use crate::utils::errors::GdtfError;
@@ -13,7 +14,7 @@ use crate::utils::read::TestReadGdtf;
 pub mod cri;
 
 ///Contains Color Rendering Indexes (CRI) for a single color temperature
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct CriGroup {
     ///Color temperature; Default value: 6 000; Unit: Kelvin
     pub color_temperature: f32,

--- a/src/fixture_type/physical_descriptions/dmx_profiles/mod.rs
+++ b/src/fixture_type/physical_descriptions/dmx_profiles/mod.rs
@@ -1,4 +1,5 @@
 //!Defines DMX profile descriptions.
+use serde::{Serialize, Deserialize};
 use quick_xml::events::attributes::Attribute;
 use quick_xml::events::BytesStart;
 use quick_xml::Reader;
@@ -8,7 +9,7 @@ use crate::utils::read::ReadGdtf;
 #[cfg(test)]
 use crate::utils::read::TestReadGdtf;
 
-#[derive(Debug, PartialEq, Default, Clone)]
+#[derive(Debug, PartialEq, Default, Clone, Serialize, Deserialize)]
 ///Defines DMX profile descriptions.
 pub struct DmxProfile {}
 

--- a/src/fixture_type/physical_descriptions/emitters/mod.rs
+++ b/src/fixture_type/physical_descriptions/emitters/mod.rs
@@ -2,6 +2,7 @@
 use quick_xml::events::attributes::Attribute;
 use quick_xml::events::BytesStart;
 use quick_xml::Reader;
+use serde::{Serialize, Deserialize};
 
 use crate::fixture_type::physical_descriptions::measurement::Measurement;
 use crate::utils::errors::GdtfError;
@@ -13,7 +14,7 @@ use crate::utils::units::color_cie::ColorCie;
 use crate::utils::units::name::Name;
 
 ///Defines the description of the emitter
-#[derive(Debug, PartialEq, Clone, Default)]
+#[derive(Debug, PartialEq, Clone, Default, Serialize, Deserialize)]
 pub struct Emitter {
     ///Approximate absolute color point if applicable. Omit for non-visible emitters (e.g., UV). For Y give relative value compared to overall output defined in property Luminous Flux of related Beam Geometry (transmissive case).
     pub color: Option<ColorCie>,

--- a/src/fixture_type/physical_descriptions/filters/mod.rs
+++ b/src/fixture_type/physical_descriptions/filters/mod.rs
@@ -2,6 +2,7 @@
 use quick_xml::events::attributes::Attribute;
 use quick_xml::events::BytesStart;
 use quick_xml::Reader;
+use serde::{Deserialize, Serialize};
 
 use crate::fixture_type::physical_descriptions::measurement::Measurement;
 use crate::utils::errors::GdtfError;
@@ -12,7 +13,7 @@ use crate::utils::units::color_cie::ColorCie;
 use crate::utils::units::name::Name;
 
 ///Defines the description of the filter
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct Filter {
     ///Approximate absolute color point when this filter is the only item fully inserted into the beam and the fixture is at maximum intensity. For Y give relative value compared to overall output defined in property Luminous Flux of related Beam Geometry (transmissive case).
     pub color: ColorCie,

--- a/src/fixture_type/physical_descriptions/measurement/measurement_point/mod.rs
+++ b/src/fixture_type/physical_descriptions/measurement/measurement_point/mod.rs
@@ -2,6 +2,7 @@
 use quick_xml::events::attributes::Attribute;
 use quick_xml::events::BytesStart;
 use quick_xml::Reader;
+use serde::{Deserialize, Serialize};
 
 use crate::fixture_type::physical_descriptions::measurement::Measurement;
 use crate::utils::errors::GdtfError;
@@ -11,7 +12,7 @@ use crate::utils::read::ReadGdtf;
 use crate::utils::read::TestReadGdtf;
 
 ///The measurement point defines the energy of a specific wavelength of a spectrum
-#[derive(Debug, PartialEq, Clone, Default)]
+#[derive(Debug, PartialEq, Clone, Default, Serialize, Deserialize)]
 pub struct MeasurementPoint {
     ///Center wavelength of measurement (nm).
     pub wave_length: f32,

--- a/src/fixture_type/physical_descriptions/measurement/mod.rs
+++ b/src/fixture_type/physical_descriptions/measurement/mod.rs
@@ -5,6 +5,7 @@ use std::fmt::Debug;
 use quick_xml::events::attributes::Attribute;
 use quick_xml::events::BytesStart;
 use quick_xml::Reader;
+use serde::{Serialize, Deserialize};
 
 use crate::fixture_type::physical_descriptions::measurement::measurement_point::MeasurementPoint;
 
@@ -17,7 +18,7 @@ use crate::utils::read::TestReadGdtf;
 pub mod measurement_point;
 
 ///The measurement defines the relation between the requested output by a control channel and the physically achieved intensity
-#[derive(Debug, PartialEq, Clone, Default)]
+#[derive(Debug, PartialEq, Clone, Default, Serialize, Deserialize)]
 pub struct Measurement {
     ///For additive color mixing: uniquely given emitter intensity DMX percentage. Value range between > 0 and ≤ 100.
     ///For subtractive color mixing: uniquely given flag insertion DMX percentage. Value range between 0 and 100.
@@ -150,7 +151,7 @@ impl TestReadGdtf for Measurement {
 //-----------------------------------------------------------------------------------------------------------------
 
 ///Interpolation scheme from the previous value.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub enum InterpolationTo {
     Linear,
     Step,

--- a/src/fixture_type/physical_descriptions/mod.rs
+++ b/src/fixture_type/physical_descriptions/mod.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 use quick_xml::events::attributes::Attribute;
 use quick_xml::events::BytesStart;
 use quick_xml::Reader;
+use serde::{Serialize, Deserialize};
 
 use crate::fixture_type::physical_descriptions::color_space::ColorSpace;
 use crate::fixture_type::physical_descriptions::connectors::Connector;
@@ -28,7 +29,7 @@ pub mod measurement;
 pub mod properties;
 
 ///Describes the physical constitution of the device
-#[derive(Debug, PartialEq, Default, Clone)]
+#[derive(Debug, PartialEq, Default, Clone, Serialize, Deserialize)]
 pub struct PhysicalDescriptions {
     ///Describes device emitters
     pub emitters: HashMap<Name, Emitter>,

--- a/src/fixture_type/physical_descriptions/properties/leg_height/mod.rs
+++ b/src/fixture_type/physical_descriptions/properties/leg_height/mod.rs
@@ -2,6 +2,7 @@
 use quick_xml::events::attributes::Attribute;
 use quick_xml::events::BytesStart;
 use quick_xml::Reader;
+use serde::{Serialize, Deserialize};
 
 use crate::utils::errors::GdtfError;
 use crate::utils::read;
@@ -10,7 +11,7 @@ use crate::utils::read::ReadGdtf;
 use crate::utils::read::TestReadGdtf;
 
 ///defines the height of the legs
-#[derive(Debug, Default, PartialEq, Clone)]
+#[derive(Debug, Default, PartialEq, Clone, Serialize, Deserialize)]
 pub struct LegHeight {
     ///Defines height of the legs – distance between the floor and the bottom base plate. Unit: meter. Default value: 0
     pub value: f32,

--- a/src/fixture_type/physical_descriptions/properties/mod.rs
+++ b/src/fixture_type/physical_descriptions/properties/mod.rs
@@ -2,6 +2,7 @@
 use quick_xml::events::attributes::Attribute;
 use quick_xml::events::BytesStart;
 use quick_xml::Reader;
+use serde::{Serialize, Deserialize};
 
 use crate::fixture_type::physical_descriptions::properties::leg_height::LegHeight;
 use crate::fixture_type::physical_descriptions::properties::operating_temperature::OperatingTemperature;
@@ -20,7 +21,7 @@ pub mod power_consumtion;
 pub mod weight;
 
 ///Defines the general properties of the device type
-#[derive(Debug, PartialEq, Default, Clone)]
+#[derive(Debug, PartialEq, Default, Clone, Serialize, Deserialize)]
 pub struct Properties {
     ///Temperature range in which the device can be operated.
     pub operationg_temperature: Option<OperatingTemperature>,

--- a/src/fixture_type/physical_descriptions/properties/operating_temperature/mod.rs
+++ b/src/fixture_type/physical_descriptions/properties/operating_temperature/mod.rs
@@ -2,6 +2,7 @@
 use quick_xml::events::attributes::Attribute;
 use quick_xml::events::BytesStart;
 use quick_xml::Reader;
+use serde::{Serialize, Deserialize};
 
 use crate::utils::errors::GdtfError;
 use crate::utils::read;
@@ -10,7 +11,7 @@ use crate::utils::read::ReadGdtf;
 use crate::utils::read::TestReadGdtf;
 
 ///defines the ambient operating temperature range
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct OperatingTemperature {
     ///Lowest temperature the device can be operated. Unit: °C. Default value: 0
     pub low: f32,

--- a/src/fixture_type/physical_descriptions/properties/power_consumtion/mod.rs
+++ b/src/fixture_type/physical_descriptions/properties/power_consumtion/mod.rs
@@ -2,6 +2,7 @@
 use quick_xml::events::attributes::Attribute;
 use quick_xml::events::BytesStart;
 use quick_xml::Reader;
+use serde::{Serialize, Deserialize};
 
 use crate::fixture_type::physical_descriptions::properties::Properties;
 use crate::utils::errors::GdtfError;
@@ -12,7 +13,7 @@ use crate::utils::read::TestReadGdtf;
 use crate::utils::units::node::Node;
 
 ///defines the maximum power consumption per connector
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct PowerConsumtion {
     ///Defines the power consumption of the connector at full load. Unit: VA. Default value: 0
     pub value: f32,

--- a/src/fixture_type/physical_descriptions/properties/weight/mod.rs
+++ b/src/fixture_type/physical_descriptions/properties/weight/mod.rs
@@ -2,6 +2,7 @@
 use quick_xml::events::attributes::Attribute;
 use quick_xml::events::BytesStart;
 use quick_xml::Reader;
+use serde::{Serialize, Deserialize};
 
 use crate::utils::errors::GdtfError;
 use crate::utils::read;
@@ -10,7 +11,7 @@ use crate::utils::read::ReadGdtf;
 use crate::utils::read::TestReadGdtf;
 
 ///defines the overall weight of the device
-#[derive(Debug, PartialEq, Default, Clone)]
+#[derive(Debug, PartialEq, Default, Clone, Serialize, Deserialize)]
 pub struct Weight {
     ///Weight of the device including all accessories. Unit: kilogram. Default value: 0
     pub value: f32,

--- a/src/fixture_type/wheel/mod.rs
+++ b/src/fixture_type/wheel/mod.rs
@@ -5,6 +5,7 @@ use std::fmt::Debug;
 use quick_xml::events::attributes::Attribute;
 use quick_xml::events::BytesStart;
 use quick_xml::Reader;
+use serde::{Serialize, Deserialize};
 
 use crate::fixture_type::wheel::slot::Slot;
 use crate::utils::errors::GdtfError;
@@ -16,7 +17,7 @@ use crate::utils::units::name::Name;
 pub mod slot;
 
 ///Each wheel describes a single physical or virtual wheel of the fixture type.
-#[derive(Debug, PartialEq, Default, Clone)]
+#[derive(Debug, PartialEq, Default, Clone, Serialize, Deserialize)]
 pub struct Wheel {
     /// All slots for the wheel
     pub slots: HashMap<Name, Slot>,

--- a/src/fixture_type/wheel/slot/animation_system/mod.rs
+++ b/src/fixture_type/wheel/slot/animation_system/mod.rs
@@ -4,6 +4,7 @@ use std::fmt::Debug;
 use quick_xml::events::attributes::Attribute;
 use quick_xml::events::BytesStart;
 use quick_xml::Reader;
+use serde::{Deserialize, Serialize};
 
 use crate::fixture_type::wheel::slot::Slot;
 use crate::utils::errors::GdtfError;
@@ -14,7 +15,7 @@ use crate::utils::units::pixel::Pixel;
 use crate::utils::units::pixel_array::PixelArray;
 
 ///Defines the animation system disk and it describes the animation system behavior
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct AnimationSystem {
     ///First Point of the Spline describing the path of animation system in the beam in relation to the middle of the Media File
     pub p1: PixelArray,

--- a/src/fixture_type/wheel/slot/facet/mod.rs
+++ b/src/fixture_type/wheel/slot/facet/mod.rs
@@ -5,6 +5,7 @@ use std::fmt::Debug;
 use quick_xml::events::attributes::Attribute;
 use quick_xml::events::BytesStart;
 use quick_xml::Reader;
+use serde::{Deserialize, Serialize};
 
 use crate::fixture_type::wheel::slot::Slot;
 use crate::utils::errors::GdtfError;
@@ -15,7 +16,7 @@ use crate::utils::units::color_cie::{ColorCie, COLOR_CIE_WHITE};
 use crate::utils::units::rotation::Rotation;
 
 /// Contains information about PrismFacet for a wheel slot
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct Facet {
     ///Color of prism facet, Default value: {0.3127, 0.3290, 100.0} (white)
     pub color: ColorCie,

--- a/src/fixture_type/wheel/slot/mod.rs
+++ b/src/fixture_type/wheel/slot/mod.rs
@@ -4,6 +4,7 @@ use std::fmt::Debug;
 use quick_xml::events::attributes::Attribute;
 use quick_xml::events::BytesStart;
 use quick_xml::Reader;
+use serde::{Serialize, Deserialize};
 
 use crate::fixture_type::wheel::slot::animation_system::AnimationSystem;
 use crate::fixture_type::wheel::slot::facet::Facet;
@@ -21,7 +22,7 @@ pub mod animation_system;
 pub mod facet;
 
 /// Represents a slot on a wheel
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct Slot {
     /// Color of the wheel slot, Default value: {0.3127, 0.3290, 100.0} (white) For Y give relative value compared to overall output defined in property Luminous Flux of related Beam Geometry (transmissive case)
     pub color: ColorCie,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,7 @@ use std::path::Path;
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::events::attributes::Attribute;
 use quick_xml::Reader;
+use serde::{Deserialize, Serialize};
 
 use crate::fixture_type::FixtureType;
 use crate::utils::errors::GdtfError;
@@ -82,7 +83,7 @@ pub mod fixture_type;
 pub mod utils;
 
 ///Describes the hierarchical and logical structure and controls of any type of controllable device (e.g. luminaires, fog machines, etc.) in the lighting and entertainment industry.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct Gdtf {
     ///The DataVersion attribute defines the minimal version of compatibility
     pub data_version: DataVersion,
@@ -195,7 +196,7 @@ impl TryFrom<&Path> for Gdtf {
 //-----------------------------------------------------------------------------------------------------------------
 
 ///The DataVersion attribute defines the minimal version of compatibility. The Version format is “Major.Minor”, where major and minor is Uint with size 1 byte
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub enum DataVersion {
     ///Enum for GDTF Version 1.0
     Version1_0,

--- a/src/utils/units/attribute_name.rs
+++ b/src/utils/units/attribute_name.rs
@@ -6,11 +6,12 @@ use std::str::FromStr;
 use lazy_static::lazy_static;
 use quick_xml::events::attributes::Attribute;
 use regex::{Regex, RegexSet, SetMatches};
+use serde::{Serialize, Deserialize};
 
 use crate::utils::read;
 use crate::utils::units::name::{GdtfNameError, Name};
 
-#[derive(Debug, PartialEq, Eq, Clone, Hash)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize)]
 ///AttributeName is an enum for preferred Names used in GDTF for Attributes. It contains an option UserDefined(Name) which can contain all other Names for Atttribute
 pub enum AttributeName {
     ///Fallback if a user-defined Name for an Attribute was used

--- a/src/utils/units/color_cie.rs
+++ b/src/utils/units/color_cie.rs
@@ -5,11 +5,12 @@ use std::fmt::Debug;
 use std::str::FromStr;
 
 use quick_xml::events::attributes::Attribute;
+use serde::{Serialize, Deserialize};
 
 use crate::utils::read;
 
 ///CIE color representation xyY 1931 used in GDTF
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 #[allow(non_snake_case)]
 pub struct ColorCie {
     ///x for color representation xyY 1931

--- a/src/utils/units/connector_type.rs
+++ b/src/utils/units/connector_type.rs
@@ -1,12 +1,13 @@
 //!A list of predefined connectors or Other with Name
 use quick_xml::events::attributes::Attribute;
+use serde::{Serialize, Deserialize};
 
 use crate::utils::errors::GdtfError;
 use crate::utils::read;
 use crate::utils::units::name::Name;
 
 ///A list of predefined connectors or Other with Name
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 #[allow(non_camel_case_types)]
 pub enum ConnectorType {
     ///BNC connector

--- a/src/utils/units/dmx_value.rs
+++ b/src/utils/units/dmx_value.rs
@@ -2,6 +2,7 @@
 use std::error::Error;
 use std::fmt::{Display, Formatter};
 use std::str::{FromStr, Utf8Error};
+use serde::{Serialize, Deserialize};
 
 use quick_xml::events::attributes::Attribute;
 
@@ -11,7 +12,7 @@ use crate::utils::read;
 /// Special type to define DMX value where n is the byte count. The byte count can be individually specified without depending on the resolution of the DMX Channel.
 /// By default byte mirroring is used for the conversion. So 255/1 in a 16 bit channel will result in 65535.
 /// You can use the byte shifting operator to use byte shifting for the conversion. So 255/1s in a 16 bit channel will result in 65280.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 #[allow(non_snake_case)]
 pub struct DmxValue {
     ///The initial value without byte shift

--- a/src/utils/units/guid.rs
+++ b/src/utils/units/guid.rs
@@ -5,6 +5,7 @@ use std::fmt::{Display, Formatter};
 use std::str::Utf8Error;
 
 use quick_xml::events::attributes::Attribute;
+use serde::{Serialize, Deserialize};
 
 use crate::utils::read;
 
@@ -44,7 +45,7 @@ const CHAR_E_AS_U8: u8 = 0x45;
 const CHAR_F_AS_U8: u8 = 0x46;
 
 ///GUID representation used in FixtureType in GDTF
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct Guid(pub [u8; 16]);
 
 impl Guid {

--- a/src/utils/units/name.rs
+++ b/src/utils/units/name.rs
@@ -3,13 +3,14 @@ use std::error::Error;
 use std::fmt;
 
 use quick_xml::events::attributes::Attribute;
+use serde::{Serialize, Deserialize};
 use unicode_segmentation::UnicodeSegmentation;
 
 use crate::utils::read;
 
 ///Name representation used in GDTF spec
 ///Name contains a String that only can hold letters with restricted literals `[32..=122] = (SPACE..='z')` due to GDTF specifications.
-#[derive(Debug, PartialEq, Eq, Clone, Hash)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize)]
 pub struct Name(pub String);
 
 ///Default is an empty Name

--- a/src/utils/units/node.rs
+++ b/src/utils/units/node.rs
@@ -4,11 +4,12 @@ use std::fmt;
 use std::fmt::{Display, Formatter};
 
 use quick_xml::events::attributes::Attribute;
+use serde::{Deserialize, Serialize};
 
 use crate::utils::read;
 use crate::utils::units::name::{GdtfNameError, Name};
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct Node(pub Vec<Name>);
 
 ///Node representation used in GDTF. A Node is a link to another xml node

--- a/src/utils/units/physical_unit.rs
+++ b/src/utils/units/physical_unit.rs
@@ -3,9 +3,10 @@
 use quick_xml::events::attributes::Attribute;
 
 use crate::utils::read;
+use serde::{Serialize, Deserialize};
 
 ///Physical Unit representation used in GDTF
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub enum PhysicalUnit {
     None,
     Percent,

--- a/src/utils/units/pixel.rs
+++ b/src/utils/units/pixel.rs
@@ -7,11 +7,12 @@ use std::num::ParseFloatError;
 use std::str::FromStr;
 
 use quick_xml::events::attributes::Attribute;
+use serde::{Serialize, Deserialize};
 
 use crate::utils::read;
 
 ///Integer value representing one Pixel inside a MediaFile. Pixel count starts with zero in the top left corner.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct Pixel(pub f32);
 
 impl Pixel {

--- a/src/utils/units/pixel_array.rs
+++ b/src/utils/units/pixel_array.rs
@@ -5,12 +5,13 @@ use std::fmt;
 use std::fmt::{Display, Formatter};
 
 use quick_xml::events::attributes::Attribute;
+use serde::{Serialize, Deserialize};
 
 use crate::utils::read;
 use crate::utils::units::pixel::{GdtfPixelError, Pixel};
 
 ///First Pixel is X-axis and second is Y-axis
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct PixelArray(pub Pixel, pub Pixel);
 
 impl PixelArray {

--- a/src/utils/units/resource.rs
+++ b/src/utils/units/resource.rs
@@ -1,11 +1,12 @@
 //!Module for the unit Resource used in GDTF
 
 use quick_xml::events::attributes::Attribute;
+use serde::{Serialize, Deserialize};
 
 use crate::utils::read;
 
 ///File name of the resource file without extension and without subfolder.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct Resource(pub String);
 
 impl Resource {

--- a/src/utils/units/rotation.rs
+++ b/src/utils/units/rotation.rs
@@ -9,11 +9,12 @@ use std::str::FromStr;
 use lazy_static::lazy_static;
 use quick_xml::events::attributes::Attribute;
 use regex::Regex;
+use serde::{Serialize, Deserialize};
 
 use crate::utils::read;
 
 ///The Rotation matrix consists of 3*3 floats. Stored as row-major matrix, i.e. each row of the matrix is stored as a 3-component vector. Mathematical definition of the matrix is column-major, i.e. the matrix rotation is stored in the three columns. Metric system, right-handed Cartesian coordinates XYZ
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct Rotation(pub [[f32; 3]; 3]);
 
 impl Rotation {


### PR DESCRIPTION
Hello @michaelhugi,

first of all: Thank you for your work! This helps me allot!

## Reasoning

While working the first bits with your projekt, i was passing the Gdtf struct around. This worked fine in my app, but i also have to provide some rest endpoints. To make it passable to many rest frameworks (axum in my case) the struct needs to be Serializable with serde. I thought, that that would be a good addition to your crate to make it more available to others.

## What i did

I added serde as a dependency and simply added the serde derive macro to the struct and each sub struct that required the macro. No logic code written.